### PR TITLE
Use inertial scaling for rigid body quaternion

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ $ python -c 'import julia; julia.install()'
 package from the command line with
 
 ```console
-$ julia -e 'using Pkg; Pkg.add(PackageSpec(url="https://github.com/salilab/HMCUtilities.jl", rev="v0.2.1"))'
+$ julia -e 'using Pkg; Pkg.add(PackageSpec(url="https://github.com/salilab/HMCUtilities.jl", rev="v0.2.2"))'
 ```
 
 Then install this module using the


### PR DESCRIPTION
Initial warm-up of systems with rigid bodies is inefficient because particles often need to move on the scale of 10s to hundreds of units (angstroms), but quaternions sampled in the same units completely flip on those same scales in the latent space. Much of initial warm-up is wasted learning this scaling, which we already know.

This PR introduces an intertial-based scaling of the latent space of rigid body quaternions based on pulling back the Euclidean metric on each member to the quaternion. The result is that larger rigid bodies tumble more slowly than smaller rigid bodies, and the members of the bodies move initially on the same scale as particles outside the bodies. Initial scaling is less bad, and warm-up runs faster.

This PR uses https://github.com/salilab/HMCUtilities.jl/pull/1

cc @ichem001 